### PR TITLE
Improvement/choose config branch from pipeline params

### DIFF
--- a/vars/continuousDeployment.groovy
+++ b/vars/continuousDeployment.groovy
@@ -5,9 +5,11 @@ import com.duvalhub.processbranchname.ProcessBranchNameResponse
 import com.duvalhub.deploy.DeployRequest
 import com.duvalhub.initializeworkdir.InitializeWorkdirIn
 
-def call() {
+def call(Map params) {
     dockerSlave() {
         InitializeWorkdirIn initializeWorkdirIn = new InitializeWorkdirIn()
+        initializeWorkdirIn.configGitBranch = params.configGitBranch
+
         AppConfig conf = initializeWorkdir.stage(initializeWorkdirIn)
 
         ProcessBranchNameRequest processBranchNameRequest = new ProcessBranchNameRequest(BRANCH_NAME)

--- a/vars/continuousDeployment.groovy
+++ b/vars/continuousDeployment.groovy
@@ -8,7 +8,7 @@ import com.duvalhub.initializeworkdir.InitializeWorkdirIn
 def call(Map params) {
     dockerSlave() {
         InitializeWorkdirIn initializeWorkdirIn = new InitializeWorkdirIn()
-        initializeWorkdirIn.configGitBranch = params.configGitBranch
+        initializeWorkdirIn.configGitBranch = params?.configGitBranch
 
         AppConfig conf = initializeWorkdir.stage(initializeWorkdirIn)
 


### PR DESCRIPTION
Allows to do `continuousDeployment(configGitBranch: 'akouna-matata')` to use the config branch 'akouna-matata'