### PR TITLE
"improvement/allow-config-from-Jenkinsfile"

### DIFF
--- a/vars/continuousDeployment.groovy
+++ b/vars/continuousDeployment.groovy
@@ -9,6 +9,7 @@ def call(Map params) {
     dockerSlave() {
         InitializeWorkdirIn initializeWorkdirIn = new InitializeWorkdirIn()
         initializeWorkdirIn.configGitBranch = params?.configGitBranch
+        initializeWorkdirIn.appConfig = params?.config
 
         AppConfig conf = initializeWorkdir.stage(initializeWorkdirIn)
 


### PR DESCRIPTION
Allow to use the Jenkinsfile to pass in pipeline configurations instead of having to create a new config file in the pipeline configs repository